### PR TITLE
Graceful handling of 503 errors

### DIFF
--- a/across_client/base/common.py
+++ b/across_client/base/common.py
@@ -199,6 +199,8 @@ class ACROSSBase:
                 for k, v in self._schema.model_validate(req.json()):
                     setattr(self, k, v)
                 return True
+            elif req.status_code == 503:
+                print("ERROR: ", req.status_code, "Service Unavailable for ", req.url)
             else:
                 print("ERROR: ", req.status_code, req.json())
                 req.raise_for_status()


### PR DESCRIPTION
Currently, getting a 503 error causes req.json() to throw an error too, this just stops that from happening and prints a useful message instead.